### PR TITLE
Update ParserFunction.ts

### DIFF
--- a/src/classes/core/ParserFunction.ts
+++ b/src/classes/core/ParserFunction.ts
@@ -87,9 +87,11 @@ class ParserFunction {
     const resolvedFields = [];
 
     for (let i = 0; i < this.fields.length; i++) {
-      if (indexes && indexes.find((index) => index !== i)) {
-        continue;
+      // вроде должно фиксануть ошибку :D
+      if (indexes && indexes.indexOf(i) === -1) {
+          continue;
       }
+
 
       const field = this.fields[i];
       const overloads = this.findOverloads(field);


### PR DESCRIPTION
```
Метод <ParserFunction>.resolveFields странно работает со вторым параметром. Когда я работал над разработкой $if/$endIf, я создал $get/$let, чтобы посмотреть, будет ли работать контекст функции внутри $if. Я также думаю, почему бы не сделать так, чтобы resolveFields парсил только определённые параметры. Я указал массив индексов [0, 1], и на выходе получил следующее:
$let[arr;true]
$print[$get[arr]] // вместо true получил undefined

Я отладил консоль и обнаружил, что при индексе 0 я получил true, а при индексе 1 получил undefined. 

```

- [X] Fixed 