### PR TITLE
Changed FunctionManager to AoiFunction

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean:dist": "rm -rf dist/",
     "uglifyjs": "find ./dist/src/function -name \"*.js\" -type f -print0 | xargs -0 uglifyjs --in-situ",
-    "build:release": "npm run clean:dist && tsc && npm run uglifyjs"
+    "build:release": "npm run clean:dist && tsc && tsc-alias && npm run uglifyjs"
   },
   "engines": {
     "node": ">=16"
@@ -42,7 +42,8 @@
     "aoi.js"
   ],
   "dependencies": {
-    "@aoitelegram/database": "^0.2.1",
+    "@aoitelegram/database": "^1.0.0",
+    "@aoitelegram/plugins": "^1.0.0",
     "chalk": "^4.1.2",
     "figlet": "^1.7.0",
     "fs-extra": "^11.2.0",
@@ -63,6 +64,8 @@
     "@types/long-timeout": "^0.1.2",
     "@types/ms": "^0.7.34",
     "@types/node": "^18.19.26",
-    "@types/node-fetch": "^2.6.11"
+    "@types/node-fetch": "^2.6.11",
+    "tsc-alias": "^1.8.8",
+    "typescript": "^5.4.5"
   }
 }

--- a/src/classes/AoiFunction.ts
+++ b/src/classes/AoiFunction.ts
@@ -7,7 +7,7 @@ import type {
   ICallbackReject,
 } from "./core/";
 
-class FunctionManager {
+class AoiFunction {
   public name: string;
   public params: string[];
   public aliases: string[];
@@ -48,7 +48,7 @@ class FunctionManager {
     this.code = ("code" in parameters && parameters.code) || "";
   }
 
-  setName(name: string): FunctionManager {
+  setName(name: string): AoiFunction {
     if (typeof name !== "string") {
       throw new AoijsTypeError(
         `The expected type is 'string', but received type ${typeof name}`,
@@ -58,7 +58,7 @@ class FunctionManager {
     return this;
   }
 
-  setAliases(aliases: string | string[]): FunctionManager {
+  setAliases(aliases: string | string[]): AoiFunction {
     if (typeof aliases !== "string" && !Array.isArray(aliases)) {
       throw new AoijsTypeError(
         `The expected type is 'string | array', but received type ${typeof aliases}`,
@@ -74,7 +74,7 @@ class FunctionManager {
     fields:
       | { name?: string; required: boolean; rest?: boolean }
       | { name?: string; required: boolean; rest?: boolean }[],
-  ): FunctionManager {
+  ): AoiFunction {
     if (this.type === "aoitelegram") {
       throw new AoijsTypeError(
         "Methods for type 'javascript' are not accessible when the type is set to 'aoitelegram'",
@@ -96,7 +96,7 @@ class FunctionManager {
     return this;
   }
 
-  setInside(inside: { name?: string; required: boolean }): FunctionManager {
+  setInside(inside: { name?: string; required: boolean }): AoiFunction {
     if (this.type === "aoitelegram") {
       throw new AoijsTypeError(
         "Methods for type 'javascript' are not accessible when the type is set to 'aoitelegram'",
@@ -106,7 +106,7 @@ class FunctionManager {
     return this;
   }
 
-  setBrackets(brackets: boolean = true): FunctionManager {
+  setBrackets(brackets: boolean = true): AoiFunction {
     if (typeof brackets !== "boolean") {
       throw new AoijsTypeError(
         `The expected type is 'boolean', but received type ${typeof brackets}`,
@@ -122,7 +122,7 @@ class FunctionManager {
       func: ParserFunction,
       code?: string,
     ) => PossiblyAsync<ICallbackResolve | ICallbackReject>,
-  ): FunctionManager {
+  ): AoiFunction {
     if (this.type === "aoitelegram") {
       throw new AoijsTypeError(
         "Methods for type 'javascript' are not accessible when the type is set to 'aoitelegram'",
@@ -137,7 +137,7 @@ class FunctionManager {
     return this;
   }
 
-  setParam(params: string | string[]): FunctionManager {
+  setParam(params: string | string[]): AoiFunction {
     if (this.type !== "aoitelegram") {
       throw new AoijsTypeError(
         "This method is only accessible for type 'aoitelegram'",
@@ -154,7 +154,7 @@ class FunctionManager {
     return this;
   }
 
-  setCode(code: string): FunctionManager {
+  setCode(code: string): AoiFunction {
     if (this.type !== "aoitelegram") {
       throw new AoijsTypeError(
         "This method is only accessible for type 'aoitelegram'",
@@ -277,4 +277,4 @@ class FunctionManager {
   }
 }
 
-export { FunctionManager };
+export { AoiFunction };

--- a/src/function/condition/endIf.ts
+++ b/src/function/condition/endIf.ts
@@ -1,6 +1,6 @@
-import { FunctionManager } from "../../classes/FunctionManager";
+import { AoiFunction } from "@structures/AoiFunction";
 
-export default new FunctionManager()
+export default new AoiFunction()
   .setName("$endIf")
   .setBrackets(false)
   .onCallback(async (context, func) => {

--- a/src/function/condition/if.ts
+++ b/src/function/condition/if.ts
@@ -1,6 +1,6 @@
-import { FunctionManager } from "../../classes/FunctionManager";
+import { AoiFunction } from "@structures/AoiFunction";
 
-export default new FunctionManager()
+export default new AoiFunction()
   .setName("$if")
   .setBrackets(true)
   .setFields({ required: true })

--- a/src/function/condition/onlyIf.ts
+++ b/src/function/condition/onlyIf.ts
@@ -1,6 +1,6 @@
-import { FunctionManager } from "../../classes/FunctionManager";
+import { AoiFunction } from "@structures/AoiFunction";
 
-export default new FunctionManager()
+export default new AoiFunction()
   .setName("$onlyIf")
   .setBrackets(true)
   .setFields({ required: true })

--- a/src/function/message/message.ts
+++ b/src/function/message/message.ts
@@ -1,6 +1,6 @@
-import { FunctionManager } from "../../classes/FunctionManager";
+import { AoiFunction } from "@structures/AoiFunction";
 
-export default new FunctionManager()
+export default new AoiFunction()
   .setName("$message")
   .setBrackets(false)
   .onCallback((context, func) => {

--- a/src/function/message/replyMessage.ts
+++ b/src/function/message/replyMessage.ts
@@ -1,6 +1,6 @@
-import { FunctionManager } from "../../classes/FunctionManager";
+import { AoiFunction } from "@structures/AoiFunction";
 
-export default new FunctionManager()
+export default new AoiFunction()
   .setName("$replyMessage")
   .setBrackets(true)
   .setFields({

--- a/src/function/util/eval.ts
+++ b/src/function/util/eval.ts
@@ -1,6 +1,6 @@
-import { FunctionManager } from "../../classes/FunctionManager";
+import { AoiFunction } from "@structures/AoiFunction";
 
-export default new FunctionManager()
+export default new AoiFunction()
   .setName("$eval")
   .setBrackets(true)
   .setFields({ required: true })

--- a/src/function/util/get.ts
+++ b/src/function/util/get.ts
@@ -1,6 +1,6 @@
-import { FunctionManager } from "../../classes/FunctionManager";
+import { AoiFunction } from "@structures/AoiFunction";
 
-export default new FunctionManager()
+export default new AoiFunction()
   .setName("$get")
   .setBrackets(true)
   .setFields({ required: true })

--- a/src/function/util/let.ts
+++ b/src/function/util/let.ts
@@ -1,6 +1,6 @@
-import { FunctionManager } from "../../classes/FunctionManager";
+import { AoiFunction } from "@structures/AoiFunction";
 
-export default new FunctionManager()
+export default new AoiFunction()
   .setName("$let")
   .setBrackets(true)
   .setFields({ required: true })

--- a/src/function/util/ping.ts
+++ b/src/function/util/ping.ts
@@ -1,6 +1,7 @@
-import { FunctionManager } from "../../classes/FunctionManager";
+import { AoiFunction } from "@structures/AoiFunction";
 
-export default new FunctionManager()
+export default new 
+    AoiFunction()
   .setName("$ping")
   .setBrackets(false)
   .onCallback(async (context, func) => {

--- a/src/function/util/print.ts
+++ b/src/function/util/print.ts
@@ -1,6 +1,6 @@
-import { FunctionManager } from "../../classes/FunctionManager";
+import { AoiFunction } from "@structures/AoiFunction";
 
-export default new FunctionManager()
+export default new AoiFunction()
   .setName("$print")
   .setBrackets(true)
   .setFields({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,13 +6,19 @@
     "noEmit": false,
     "importHelpers": true,
     "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./",
     "resolveJsonModule": true,
     "declarationDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitAny": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "paths": {
+        "@structures/*": ["src/classes/*"]
+    }
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
I have changed FunctionManager class name to "AoiFunction" because the old name is confusing, since "FunctionManager" should be a class that holds all functions from this library, so "AoiFunction" makes more sense and it's less confusing.

## Additional changes made
- Bumped `@aoitelegram/database` and `@aoitelegram/plugins`.
- Added path aliases to avoid relative imports. (tsc-alias handles this)
- Added TypeScript as development dependency.